### PR TITLE
Use npm's htmltojsx rather than requiring dependency via git path

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "htmltojsx": "git://github.com/reactjs/react-magic.git",
+    "htmltojsx": "^0.3.0",
     "jsdom-no-contextify": "^3.1.0",
     "yargs": "^6.5.0"
   }


### PR DESCRIPTION
This PR is purely selfish.  I bumped into an issue inside a docker container that was attempting to do an `npm install` of a project using svg-to-react-cli, as the container didn't have git installed.

Since this package is provided through npm, the associated commit simply uses that library, rather than going directly to the source via the github path.

